### PR TITLE
Remove embedded Tweets to make blog posts more sustainable

### DIFF
--- a/_posts/2020-03-05-why-surface-will-be-decade-developer-laptop.md
+++ b/_posts/2020-03-05-why-surface-will-be-decade-developer-laptop.md
@@ -3,23 +3,14 @@ layout: post
 title: Why The Surface Will Be This Decade's Developer Laptop
 ---
 
-**July 2020 Update**: Apple's WWDC this year was incredible.
+**July 2020 Update:** Apple's WWDC this year was incredible.
 The pivot to ARM-based Apple Silicon and macOS 11 was very reassuring, as a Mac fan.
 Moreover, the MacBook Air and MacBook Pro 13-inch have been refreshed since this article was posted, and have addressed most of the 2016-2019 lineup's issues.
 
 I think the core message of this article still stands: Microsoft has a potential winner on its hands with the Surface lineup.
 Let's see how this plays out over time.
 
-## Original Post Begins
-
-I never realized how much I wanted [@jack](https://twitter.com/nickagerace) to include the edit button until I re-read this tweet...
-
-<blockquote class="twitter-tweet"><p lang="en" dir="ltr">The <a href="https://twitter.com/surface?ref_src=twsrc%5Etfw">@surface</a> with WSL will the MacBook Pro of the next decade.</p>&mdash; Nick Gerace (@nickagerace) <a href="https://twitter.com/nickagerace/status/1213581804961177601?ref_src=twsrc%5Etfw">January 4, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-I regret the error, but I stand by that proclamation: "The [@surface](https://twitter.com/surface) with WSL will **be** the MacBook Pro of the next decade."
-
-That's quite a bold statement, especially from an industry newbie.
-Let's break it down.
+*(original post begins below)*
 
 ## "Every Developer Needs A MacBook Pro"
 

--- a/_posts/2020-07-01-fedora-silverblue-for-rust-development.md
+++ b/_posts/2020-07-01-fedora-silverblue-for-rust-development.md
@@ -4,42 +4,35 @@ title: Fedora Silverblue for Rust Development
 ---
 
 This month was a lot busier than expected, including things that were [much more important than software](https://nickgerace.dev/post/action-and-experience).
-Instead of editing, polishing, publishing a lengthy blog post, I opted for a "Tweetstorm" in its place.
 
-I'll embed the first Tweet below, but include the raw text here as well.
+Instead of editing, polishing, publishing a lengthy blog post, I opted for a "Tweetstorm"-style post in its place.
 Here's my experience with using Fedora Silverblue for Rust Development.
-
-## Embedded Tweet
-
-<blockquote class="twitter-tweet"><p lang="en" dir="ltr">This month was a lot busier than expected, so instead of publishing a blog post on using Fedora Silverblue for Rust Development, I&#39;ll be writing this thread instead 🧵. Let&#39;s go!<br>(cc: <a href="https://twitter.com/teamsilverblue?ref_src=twsrc%5Etfw">@teamsilverblue</a>, <a href="https://twitter.com/rustlang?ref_src=twsrc%5Etfw">@rustlang</a>)</p>&mdash; Nick Gerace (@nickgeracehacks) <a href="https://twitter.com/nickgeracehacks/status/1277997079315578887?ref_src=twsrc%5Etfw">June 30, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 ## Tweetstorm Begins
 
-Posted at 12:07 PM EST on June 30, 2020 by [@nickgeracehacks](https://twitter.com/nickgeracehacks).
-
-### Tweet 1
+##### 01
 
 This month was a lot busier than expected, so instead of publishing a blog post on using Fedora Silverblue for Rust Development, I'll be writing this thread instead 🧵. Let's go!
 (cc: [@teamsilverblue](https://twitter.com/teamsilverblue), [@rustlang](https://twitter.com/rustlang))
 
-### Tweet 2
+##### 02
 
 I recently wrote about why I use Fedora, among other Linux distros. After posting that article, I thought "wait... have I even tried Fedora Silverblue before?" Distraught in my failing Fedora evangelism, I quickly downloaded the ISO so that I could feel validated.
 
-### Tweet 3
+##### 03
 
 Jokes, aside I drove the immutable desktop OS in a virtual machine, and I have to say... it's awesome.
 
-### Tweet 4
+##### 04
 
 However, I didn't really try this out for daily use. There have been many awesome posts about using containerized, GUI applications (Snap, Flatpak, Docker, etc.). For instance, 
 [@jessfraz](https://twitter.com/jessfraz)'s 2015 post is an amazing example on how to get started. ([link](https://blog.jessfraz.com/post/docker-containers-on-the-desktop/))
 
-### Tweet 5
+##### 05
 
 Instead, I looked for "edge cases", and by "edge cases", I mean "compiling big ass Rust projects". My objective was to find the limitations, and workarounds, required to develop systems-level software within Fedora Silverblue. Can you replace your workstation OS with Silverblue?
 
-### Tweet 6
+##### 06
 
 We'll get to that. The first thing I wanted to do: understand the differences (and when to use) flatpak, toolbox, and rpm-ostree. I usually followed this order...
 
@@ -49,78 +42,80 @@ We'll get to that. The first thing I wanted to do: understand the differences (a
 
 For my Rust toolchain, I primarily used Toolbox. ([link](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/))
 
-### Tweet 7
+##### 07
 
 Toolbox worked great! Sometimes, I even forgot that I was working in a container. Although, I did not benchmark build times, as this work was being done on an i7-8565U, which is already in the "eh whatever" build time arena.
 
-### Tweet 8
+##### 08
 
 Rustup and cargo worked out of the box. Great.
 
-However, "cargo install exa" failed initially. Once I installed Fedora's equivalent to "build-essential" ("Development Tools and Libraries"), installing smaller Rust projects worked well.
+However, ```cargo install exa``` failed initially. Once I installed Fedora's equivalent to "build-essential" ("Development Tools and Libraries"), installing smaller Rust projects worked well.
 
-### Tweet 9
+##### 09
 
-Our first attempted build of Redox OS broke upon running out of space in the root partition. After some searching, and performing fdisk commands, an "lvresize", and a "pvresize", we were back on track.
+Our first attempted build of Redox OS broke upon running out of space in the root partition. After some searching, and performing fdisk commands, an ```lvresize```, and a ```pvresize```, we were back on track.
 
 You'll learn a lot about LVM when using Silverblue!
 
-### Tweet 10
+##### 10
 
 I've never had that experience when using other distros, but part of the magic to Silverblue is its tight organization. You can learn more about reproducible builds, and the OS design, here: ([link](https://docs.fedoraproject.org/en-US/fedora-silverblue/))
 
-### Tweet 11
+##### 11
 
 A few trials and errors with building Redox OS led to installing several packages and tooling libraries. While obvious to some, the Toolbox container is much more barebones than Fedora Workstation. I think that's a great thing, but it's something to keep in mind.
 
-### Tweet 12
+##### 12
 
 I did not get Redox OS to fully build, but the remaining failures were at the very end. I only gave myself one or two hours per project because I wanted to maintain pace.
 
 Good news though: I think a little more time, and it would have built successfully (and launched with QEMU).
 
-### Tweet 13
+##### 13
 
 Building Krustlet worked flawlessly, but I was less fortunate when building Firecracker. That's because Firecracker is based on Docker, not Podman (+ Buildah). ([link](https://github.com/firecracker-microvm/firecracker))
 
-### Tweet 14
+##### 14
 
 Rather than disabling cgroups v2, and installing Docker, I decided to use Podman instead. Fedora Silverblue leverages containers for everything, so I wanted to keep the lower level stack as clean as possible.
 
-### Tweet 15
+##### 15
 
-I replaced every instance of "docker" with "podman" for Firecracker, and... WHAT, IT WORKED?!
+I replaced every instance of ```docker``` with ```podman``` for Firecracker, and... WHAT, IT WORKED?!
 
+```
 Compiling firecracker v0.21.0
 Finished dev [unoptimized + debuginfo] target(s) in 53.08s
 [Firecracker devtool] Build successful.
-[Firecracker devtool] Binaries placed under \<REDACTED\>
+[Firecracker devtool] Binaries placed under REDACTED
+```
 
-### Tweet 16
+##### 16
 
-I could not believe it. All it took was adding "docker (dot) io" in some places, and performing a ":%s/docker/podman/g".
+I could not believe it. All it took was adding "docker (dot) io" in some places, and performing a ```:%s/docker/podman/g```.
 
 Granted, I am not saying that this will work for all projects, but I was pleasantly surprised with the result here. ([link](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users/))
 
-### Tweet 17
+##### 17
 
 Local Kubernetes development was not as simple. Minikube offers an experimental Podman driver, and podman can simulate Kubernetes workflows. However, using kind, and many other Kubernetes tools, requires Docker and cgroups v1.
 
-### Tweet 18
+##### 18
 
 While container runtimes for Kubernetes have little to do with Silverblue, or Rust, in particular, I think the developer experience there is still worth mentioning.
 
-### Tweet 19
+##### 19
 
 Ending on a high note: it all (mostly) worked. Were the builds as fast/painless as your everyday distro? Probably not. Was that my fault? Probably so.
 
 Upfront, if you run a sound LVM setup, and a Toolbox container setup script/playbook, you may not even notice the difference.
 
-### Tweet 20
+##### 20
 
 This thread only covered the edge cases too. In exchange for a slightly more difficult systems-level building experience, you get reproducible builds, great security, and sandboxed GUI applications. Seems like a worthy tradeoff to me.
 
-### Tweet 21
+##### 21
 
 So... Can you replace your workstation OS with Silverblue?
 Yes, but immutable desktop OSes becoming a norm will take time. Do not rush.


### PR DESCRIPTION
Searched through the repository to find embedded Tweets, and links to
Tweets. They have been removed, or edited, to ensure that blog post
content is more sustainable.